### PR TITLE
LICENSE.note

### DIFF
--- a/LICENSE.note
+++ b/LICENSE.note
@@ -1,0 +1,4 @@
+Ownership of, authorship of, copyright of, responsibility for, and liability
+for the contents of `bin/` and `src/` belong solely to the owners, authors,
+and copyright holders of the individual packages therein,
+as defined in each package's own `DESCRIPTION` file and license.


### PR DESCRIPTION
While we're working on #2, I'd like to propose we at least get `LICENSE.note` in the repo to protect us against the biggest risk.